### PR TITLE
Minor fixes

### DIFF
--- a/MAKEFILE
+++ b/MAKEFILE
@@ -1,1 +1,0 @@
-gcc scansio_ftp_parse.c -O3 -lm -mtune=native -march=native -o scansio_ftp_parse

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build: scansio_ftp_parse.c
+	gcc scansio_ftp_parse.c -O3 -lm -mtune=native -march=native -o scansio_ftp_parse
+
+debug: scansio_ftp_parse.c
+	gcc scansio_ftp_parse.c -O3 -lm -mtune=native -march=native -g -o scansio_ftp_parse


### PR DESCRIPTION
- I initially wanted to fix a memory leak (not calling `free(3)` on memory `malloc(3)`'d), but found a few other things.
- at least on macOS (Sierra) I was actually getting some buffer overflows when attempting to use, so fixed those.
- There was some weird instances of using `"\0"` when I think you meant `'\0'`?
- I added a proper `Makefile`, with one build instance and one debug instance.

There are honestly some other things you could do in here, but I didn't want to change the code _too_ much. I tested it with a `zgrab` result, seems to work, but obviously some sanity testing would help. I'm down to discuss the other changes I was thinking too, which may even be faster because they'd avoid allocating memory for files & what not.

Anyway, thanks for this, it works great (I'll use it myself)!